### PR TITLE
feat: Allow customization of import classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,36 @@ imports that *can* be moved.
 type-checking-strict = true  # default false
 ```
 
+### Customizing import classification
+
+The plugin categorizes imports into application, third-party, and builtin
+based on whether they can be found in the standard library or the application path.
+
+If your application treats directories other than the root directory as
+root-level import directories, specify them here to classify imports in
+those directories as application modules instead of third-party.
+
+If you still wish to include the root directory (`.`), you must also specify it.
+
+- **setting name**: `type-checking-application-directories`
+- **type**: `list`
+
+```ini
+[flake8]
+type-checking-application-directories = .,libs  # default "."
+```
+
+If you wish to further override the classification behavior by marking certain
+modules as application modules, regardless of where they reside, specify them here.
+
+- **setting name**: `type-checking-unclassifiable-application-modules`
+- **type**: `list`
+
+```ini
+[flake]
+type-checking-unclassifiable-application-modules = os,math  # default []
+```
+
 ### Pydantic support
 
 If you use Pydantic models in your code, you should enable Pydantic support.

--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -48,6 +48,20 @@ class Plugin:
             default=False,
             help='Flag individual imports rather than looking at the module.',
         )
+        option_manager.add_option(
+            '--type-checking-application-directories',
+            comma_separated_list=True,
+            parse_from_config=True,
+            default=None,
+            help='Directories relative to the current directory to be considered application source roots.',
+        )
+        option_manager.add_option(
+            '--type-checking-unclassifiable-application-modules',
+            comma_separated_list=True,
+            parse_from_config=True,
+            default=None,
+            help='Modules to always consider application modules.',
+        )
 
         # Third-party library options
         option_manager.add_option(

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,6 +65,13 @@ description = "Utilities for refactoring imports in python-like syntax."
 category = "main"
 optional = false
 python-versions = ">=3.7"
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/steverice/classify-imports.git"
+reference = "consistent-behavior"
+resolved_reference = "74670e4973e2f1955d48880a7186c4ce40ff252d"
 
 [[package]]
 name = "colorama"
@@ -537,7 +544,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = '>=3.8'
-content-hash = "fc29baa07456bcdac7221d0392dc90f69729d0222196360c4f955fb144483603"
+content-hash = "a695fb536dedc54f37190a50dd7c806ab37ae510b0a83ae45575030c04c57e9e"
 
 [metadata.files]
 appnope = [
@@ -564,10 +571,7 @@ cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
-classify-imports = [
-    {file = "classify_imports-4.2.0-py2.py3-none-any.whl", hash = "sha256:dbbc264b70a470ed8c6c95976a11dfb8b7f63df44ed1af87328bbed2663f5161"},
-    {file = "classify_imports-4.2.0.tar.gz", hash = "sha256:7abfb7ea92149b29d046bd34573d247ba6e68cc28100c801eba4af17964fc40e"},
-]
+classify-imports = []
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 python = '>=3.8'
 flake8 = '*'
 astor = {python = "<3.9", version = "*"}
-classify-imports = '*'
+classify-imports = { git = "https://github.com/steverice/classify-imports.git", branch = "consistent-behavior" }
 
 [tool.poetry.dev-dependencies]
 pytest = '*'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,8 @@ def _get_error(example: str, *, error_code_filter: Optional[str] = None, **kwarg
         # defaults
         mock_options.extended_default_select = []
         mock_options.enable_extensions = []
+        mock_options.type_checking_application_directories = None
+        mock_options.type_checking_unclassifiable_application_modules = None
         mock_options.type_checking_pydantic_enabled = False
         mock_options.type_checking_exempt_modules = []
         mock_options.type_checking_fastapi_enabled = False

--- a/tests/test_tc001_to_tc003.py
+++ b/tests/test_tc001_to_tc003.py
@@ -216,6 +216,27 @@ def test_TC001_errors(example: str, expected: set[str]) -> None:
     assert _get_error(example, error_code_filter='TC001') == expected
 
 
+@pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests(mod, TC002))
+def test_no_application_directories(example, expected):
+    """Without the current directory marked as an application directory, it will be seen as third-party"""
+    assert _get_error(example, error_code_filter='TC002', type_checking_application_directories=[]) == expected
+
+
+@pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('conftest', TC001))
+def test_extra_application_directories(example, expected):
+    """Module should be seen as an application module if its directory is specified"""
+    assert _get_error(example, error_code_filter='TC001', type_checking_application_directories=['tests']) == expected
+
+
+@pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('pandas', TC001))
+def test_unclassifiable_application_modules_third_party(example, expected):
+    """Third-party application module should be seen as application module if specified"""
+    assert (
+        _get_error(example, error_code_filter='TC001', type_checking_unclassifiable_application_modules=['pandas'])
+        == expected
+    )
+
+
 @pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('pandas', TC002))
 def test_TC002_errors(example, expected):
     assert _get_error(example, error_code_filter='TC002') == expected
@@ -224,3 +245,12 @@ def test_TC002_errors(example, expected):
 @pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('os', TC003))
 def test_TC003_errors(example, expected):
     assert _get_error(example, error_code_filter='TC003') == expected
+
+
+@pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('os', TC001))
+def test_unclassifiable_application_modules_builtin(example, expected):
+    """Builtin application module should be seen as application module if specified"""
+    assert (
+        _get_error(example, error_code_filter='TC001', type_checking_unclassifiable_application_modules=['os'])
+        == expected
+    )


### PR DESCRIPTION
This commit adds two plugin settings that provide support for the [`classify-imports` settings](https://github.com/asottile/classify-imports/blob/8d0e115b4b95dbe6bcfafbaae2d1323ba7fbdfbf/classify_imports.py#L49-L51) that allow additional modules to be classified as application imports.